### PR TITLE
FE - Feedback 페이지에 Sync 버튼 추가

### DIFF
--- a/frontend/src/components/EditableFeedbackBox/EditableFeedbackBox.tsx
+++ b/frontend/src/components/EditableFeedbackBox/EditableFeedbackBox.tsx
@@ -7,7 +7,7 @@ import { ReactComponent as EditIcon } from '@assets/icon/edit.svg';
 
 interface PropsType {
 	feedback: EditableFeedbackType;
-	handleClickFeedback: (e, startTime: number) => void;
+	handleClickFeedback: (e, startTime: number, idx: number) => void;
 	handleDeleteFeedback: (id: number) => void;
 	handleStartEditFeedback: (id: number) => void;
 	handleEndEditFeedback: (id: number, newContent: string) => void;
@@ -34,7 +34,7 @@ const EditableFeedbackBox = (props: PropsType) => {
 
 	return (
 		<FeedbackBox
-			onClick={(e) => handleClickFeedback(e, startTime)}
+			onClick={(e) => handleClickFeedback(e, startTime, idx)}
 			ref={(elem) => (feedbackRef.current[idx] = elem)}
 		>
 			<FeedbackBox.StartTime>{startTime}</FeedbackBox.StartTime>

--- a/frontend/src/hooks/useSyncFeedbackList.ts
+++ b/frontend/src/hooks/useSyncFeedbackList.ts
@@ -19,17 +19,30 @@ const useSyncFeedbackList = () => {
 	const [currentTime, setCurrentTime] = useState(0);
 	const [focusIndex, setFocusIndex] = useState(0);
 	const [isFbClicked, setIsFbClicked] = useState(false);
+	const [isFbSync, setIsFbSync] = useState(true);
 	const feedbackRef = useRef([]);
 
-	const handleClickFeedback = useCallback((e, startTime: number) => {
-		feedbackRef.current[focusIndex].scrollIntoView({ behavior: 'smooth', block: 'start' });
-		setCurrentTime(startTime);
-		setIsFbClicked(true);
-	}, []);
+	//TODO 10초에 피드백 2개가 있다고한다면, 2번 째 10초 피드백 클릭 시에도 첫번째 10초 피드백 박스로 이동
+	const handleClickFeedback = useCallback(
+		(e, startTime: number, idx: number) => {
+			feedbackRef.current[focusIndex].scrollIntoView({ behavior: 'smooth', block: 'start' });
 
+			//CHECK 계속 if가 이렇게 추가되는게 좋은 로직인지 모르겠음???????
+			if (!isFbSync) {
+				setFocusIndex(idx);
+				return;
+			}
+			setCurrentTime(startTime);
+			setIsFbClicked(true);
+		},
+		[isFbSync]
+	);
+
+	//TODO (handleClickFeedback TODO과 같은 문제) 같은 초에서 nearestIndex가 무조건 최상위 feedback으로 설정되는 문제
 	useEffect(() => {
+		if (!isFbSync) return;
+
 		const nearestIndex = findCurrentFeedback(feedbackList, currentTime);
-		console.log(nearestIndex, feedbackList[nearestIndex].startTime);
 		if (nearestIndex !== focusIndex) setFocusIndex(nearestIndex);
 	}, [currentTime]);
 
@@ -46,6 +59,8 @@ const useSyncFeedbackList = () => {
 		setCurrentTime,
 		setIsFbClicked,
 		handleClickFeedback,
+		isFbSync,
+		setIsFbSync,
 	};
 };
 

--- a/frontend/src/pages/Feedback.tsx
+++ b/frontend/src/pages/Feedback.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import FeedbackArea from '@components/@shared/FeedbackArea/FeedbackArea';
 
 import IntervieweeVideo from '@components/IntervieweeVideo/IntervieweeVideo';
@@ -17,6 +17,8 @@ const Feedback = () => {
 		setCurrentTime,
 		setIsFbClicked,
 		handleClickFeedback,
+		isFbSync,
+		setIsFbSync,
 	} = useSyncFeedbackList();
 
 	const {
@@ -37,6 +39,9 @@ const Feedback = () => {
 				width={400}
 				controls
 			/>
+			<button type="button" onClick={() => setIsFbSync((current) => !current)}>
+				{isFbSync ? '현재 Sync 중' : '현재 UnSync 중'}
+			</button>
 			<FeedbackArea>
 				<FeedbackArea.FAScrollView>
 					{feedbackList.map((feedback, idx) => (


### PR DESCRIPTION
작업 중인 PR이라면 제목에 [WIP]을 작성해주세요.

# PR 목적 / 요약

- 비디오와 피드백 Sync 버튼 추가

# 관련 이슈

- close issue #34 


# 리뷰받고 싶은 부분 설명

1. useSyncFeedbackList에서 계속 이렇게 기능이 추가될 때 if 문으로 분기처리가 추가되는게 좋은건지 모르겠습니다.

# 특이사항

1. 지금 같은 초에 피드백이 2개 이상 있을 때, 2번째 피드백을 눌러도 무조건 첫번째 피드백으로 스크롤이 설정되는데
    피드백 리스트의 구조를 바꾸거나, 같은 초에 2개 이상 피드백이 올 수 없게 만들어야할 것 같은데
    의견을 나눠봐야할 것 같네요.
