### PR TITLE
49 room socket event 구현 및 테스트

### DIFF
--- a/backend/socket/src/constant/room.constant.ts
+++ b/backend/socket/src/constant/room.constant.ts
@@ -8,9 +8,13 @@ export enum ROOM_EVENT {
 	START_INTERVIEW = 'start_interview',
 	JOIN_INTERVIEW = 'join_interview',
 	END_INTERVIEW = 'end_interview',
+	END_FEEDBACK = 'end_feedback',
+	COUNT_FEEDBACK = 'count_feedback',
+	TERMINATE_SESSION = 'terminate_session',
 }
 export enum ROOM_STATE {
 	LOBBY = 'lobby',
 	INTERVIEW = 'interview',
 	FEEDBACK = 'feedback',
 }
+export const END_FLAG = -1;

--- a/backend/socket/src/constant/room.constant.ts
+++ b/backend/socket/src/constant/room.constant.ts
@@ -7,6 +7,7 @@ export enum ROOM_EVENT {
 	LEAVE_ROOM = 'leave_room',
 	START_INTERVIEW = 'start_interview',
 	JOIN_INTERVIEW = 'join_interview',
+	END_INTERVIEW = 'end_interview',
 }
 export enum ROOM_STATE {
 	LOBBY = 'lobby',

--- a/backend/socket/src/constant/room.constant.ts
+++ b/backend/socket/src/constant/room.constant.ts
@@ -5,4 +5,11 @@ export enum ROOM_EVENT {
 	ENTER_ROOM = 'enter_room',
 	USER_ENTER = 'user_enter',
 	LEAVE_ROOM = 'leave_room',
+	START_INTERVIEW = 'start_interview',
+	JOIN_INTERVIEW = 'join_interview',
+}
+export enum ROOM_STATE {
+	LOBBY = 'lobby',
+	INTERVIEW = 'interview',
+	FEEDBACK = 'feedback',
 }

--- a/backend/socket/src/constant/room.constant.ts
+++ b/backend/socket/src/constant/room.constant.ts
@@ -1,5 +1,8 @@
 export const ROOM_REPOSITORY_INTERFACE = 'roomRepository';
 export const MAX_COUNT = 4;
 export enum ROOM_EVENT {
-	USER_ENTER = 'userEnter',
+	CREATE_ROOM = 'create_room',
+	ENTER_ROOM = 'enter_room',
+	USER_ENTER = 'user_enter',
+	LEAVE_ROOM = 'leave_room',
 }

--- a/backend/socket/src/room/repository/inmemory-room.repository.ts
+++ b/backend/socket/src/room/repository/inmemory-room.repository.ts
@@ -16,8 +16,6 @@ export class InmemoryRoomRepository implements RoomRepository<repositoryType> {
 		if (clientId in this.repository[uuid]) throw new WsException('Internal Serval Error');
 		this.repository[uuid][clientId] = nickname;
 		this.sockets[clientId] = uuid;
-		console.log(this.repository);
-		console.log(this.sockets);
 	}
 	broadcastUserList(clientId: string, server: Server): void {
 		const uuid = this.sockets[clientId];
@@ -32,6 +30,9 @@ export class InmemoryRoomRepository implements RoomRepository<repositoryType> {
 		client.leave(uuid);
 
 		delete this.repository[uuid][client.id];
+		if (!Object.keys(this.repository[uuid])) {
+			delete this.repository[uuid];
+		}
 		// delete this.sockets[client.id];
 	}
 }

--- a/backend/socket/src/room/repository/inmemory-room.repository.ts
+++ b/backend/socket/src/room/repository/inmemory-room.repository.ts
@@ -45,8 +45,8 @@ export class InmemoryRoomRepository implements RoomRepository<repositoryType> {
 		// delete this.sockets[client.id];
 	}
 
-	startInterview(client: Socket) {
+	changeRoomState(client: Socket, state: string) {
 		const uuid = this.sockets[client.id];
-		this.roomState[uuid] = ROOM_STATE.INTERVIEW;
+		this.roomState[uuid] = state;
 	}
 }

--- a/backend/socket/src/room/repository/interface-room.repository.ts
+++ b/backend/socket/src/room/repository/interface-room.repository.ts
@@ -2,9 +2,40 @@ import { Server, Socket } from 'socket.io';
 
 export interface RoomRepository<T> {
 	repository: T;
+	/**
+	 * uuid를 key로 repository에 유저의 socket id를 저장할 객체를 생성하고
+	 * uuid를 key로 방을 식별할 수 있는 객체에 room의 상태를 LOBBY로 저장하는 메서드입니다.
+	 * @param uuid room을 식별할 수 있는 고유한 key
+	 */
 	createRoom(uuid: string): void;
+
+	/**
+	 * uuid로 방을 식별하여 유저의 socket id를 저장하는 메서드입니다.
+	 * @param clientId socket id
+	 * @param nickname user nickname
+	 * @param uuid room을 식별할 수 있는 고유한 key
+	 */
 	enterRoom(clientId: string, nickname: string, uuid: string): void;
+
+	/**
+	 * 같은 room에 속한 유저에게 broadcast하는 메서드입니다.
+	 * @param clientId socket id
+	 * @param server server instance
+	 * @param eventType broadcast할 event 이름
+	 * @Returns broadcast할 data
+	 */
 	broadcastUserList(clientId: string, server: Server, eventType: string): string;
+
+	/**
+	 * room을 나가는 메서드입니다.
+	 * @param clientId socket id
+	 */
 	leaveRoom(clientId: Socket): void;
+
+	/**
+	 * room의 상태를 변경하는 메서드입니다.
+	 * @param client socket instance
+	 * @param state room의 상태 (lobby -> interview -> feedback)
+	 */
 	changeRoomState(client: Socket, state: string): void;
 }

--- a/backend/socket/src/room/repository/interface-room.repository.ts
+++ b/backend/socket/src/room/repository/interface-room.repository.ts
@@ -6,5 +6,5 @@ export interface RoomRepository<T> {
 	enterRoom(clientId: string, nickname: string, uuid: string): void;
 	broadcastUserList(clientId: string, server: Server, eventType: string): string;
 	leaveRoom(clientId: Socket): void;
-	startInterview(client: Socket): void;
+	changeRoomState(client: Socket, state: string): void;
 }

--- a/backend/socket/src/room/repository/interface-room.repository.ts
+++ b/backend/socket/src/room/repository/interface-room.repository.ts
@@ -4,6 +4,7 @@ export interface RoomRepository<T> {
 	repository: T;
 	createRoom(uuid: string): void;
 	enterRoom(clientId: string, nickname: string, uuid: string): void;
-	broadcastUserList(data: string, server: Server): void;
+	broadcastUserList(clientId: string, server: Server, eventType: string): string;
 	leaveRoom(clientId: Socket): void;
+	startInterview(client: Socket): void;
 }

--- a/backend/socket/src/room/repository/interface-room.repository.ts
+++ b/backend/socket/src/room/repository/interface-room.repository.ts
@@ -38,4 +38,12 @@ export interface RoomRepository<T> {
 	 * @param state room의 상태 (lobby -> interview -> feedback)
 	 */
 	changeRoomState(client: Socket, state: string): void;
+
+	/**
+	 * feedback을 완료한 interviewer를 저장하는 메서드입니다.
+	 * @param clientId socket id
+	 * @param server server instance
+	 * @return 완료한 interviewer의 수
+	 */
+	countFeedback(clientId: string, server: Server): number;
 }

--- a/backend/socket/src/room/repository/interface-room.repository.ts
+++ b/backend/socket/src/room/repository/interface-room.repository.ts
@@ -1,9 +1,9 @@
-import { Server } from 'socket.io';
+import { Server, Socket } from 'socket.io';
 
 export interface RoomRepository<T> {
 	repository: T;
 	createRoom(uuid: string): void;
 	enterRoom(clientId: string, nickname: string, uuid: string): void;
 	broadcastUserList(data: string, server: Server): void;
-	leaveRoom(data: string, clientId: string): void;
+	leaveRoom(clientId: Socket): void;
 }

--- a/backend/socket/src/room/room.gateway.ts
+++ b/backend/socket/src/room/room.gateway.ts
@@ -1,3 +1,4 @@
+import { ROOM_EVENT } from '@constant';
 import { Logger } from '@nestjs/common';
 import {
 	ConnectedSocket,
@@ -16,7 +17,7 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect {
 	@WebSocketServer() server: Server;
 	private logger = new Logger('room');
 	constructor(private readonly roomSerivce: RoomService) {}
-	@SubscribeMessage('create_room')
+	@SubscribeMessage(ROOM_EVENT.CREATE_ROOM)
 	handleCreateRoom(): string {
 		const uuid = this.roomSerivce.createRoom();
 		return JSON.stringify({
@@ -27,14 +28,14 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		});
 	}
 
-	@SubscribeMessage('enter_room')
+	@SubscribeMessage(ROOM_EVENT.ENTER_ROOM)
 	handleEnterRoom(@ConnectedSocket() client: Socket, @MessageBody() data: string) {
 		this.roomSerivce.enterRoom(client, data, this.server);
 	}
 
-	@SubscribeMessage('leave_room')
-	handleLeaveRoom(@ConnectedSocket() client: Socket, @MessageBody() data: string) {
-		this.roomSerivce.leaveRoom(client, data, this.server);
+	@SubscribeMessage(ROOM_EVENT.LEAVE_ROOM)
+	handleLeaveRoom(@ConnectedSocket() client: Socket) {
+		this.roomSerivce.leaveRoom(client, this.server);
 	}
 
 	handleConnection(@ConnectedSocket() client: Socket) {
@@ -43,5 +44,6 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
 	handleDisconnect(@ConnectedSocket() client: Socket) {
 		this.logger.log(`disconnected: ${client.id}`);
+		this.roomSerivce.leaveRoom(client, this.server);
 	}
 }

--- a/backend/socket/src/room/room.gateway.ts
+++ b/backend/socket/src/room/room.gateway.ts
@@ -48,6 +48,11 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		return this.roomSerivce.endInterview(client, this.server);
 	}
 
+	@SubscribeMessage(ROOM_EVENT.END_FEEDBACK)
+	handleEndFeedback(@ConnectedSocket() client: Socket) {
+		this.roomSerivce.endFeedback(client, this.server);
+	}
+
 	handleConnection(@ConnectedSocket() client: Socket) {
 		this.logger.log(`connected: ${client.id}`);
 	}

--- a/backend/socket/src/room/room.gateway.ts
+++ b/backend/socket/src/room/room.gateway.ts
@@ -43,6 +43,11 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		return this.roomSerivce.startInterview(client, this.server);
 	}
 
+	@SubscribeMessage(ROOM_EVENT.END_INTERVIEW)
+	handleEndInterview(@ConnectedSocket() client: Socket) {
+		return this.roomSerivce.endInterview(client, this.server);
+	}
+
 	handleConnection(@ConnectedSocket() client: Socket) {
 		this.logger.log(`connected: ${client.id}`);
 	}

--- a/backend/socket/src/room/room.gateway.ts
+++ b/backend/socket/src/room/room.gateway.ts
@@ -38,6 +38,11 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		this.roomSerivce.leaveRoom(client, this.server);
 	}
 
+	@SubscribeMessage(ROOM_EVENT.START_INTERVIEW)
+	handleStartInterview(@ConnectedSocket() client: Socket) {
+		return this.roomSerivce.startInterview(client, this.server);
+	}
+
 	handleConnection(@ConnectedSocket() client: Socket) {
 		this.logger.log(`connected: ${client.id}`);
 	}

--- a/backend/socket/src/room/room.service.ts
+++ b/backend/socket/src/room/room.service.ts
@@ -1,4 +1,4 @@
-import { ROOM_EVENT, ROOM_REPOSITORY_INTERFACE, ROOM_STATE } from '@constant';
+import { END_FLAG, ROOM_EVENT, ROOM_REPOSITORY_INTERFACE, ROOM_STATE } from '@constant';
 import { Inject, Injectable } from '@nestjs/common';
 import { Server, Socket } from 'socket.io';
 import { repositoryType } from 'src/types/room.type';
@@ -43,5 +43,14 @@ export class RoomService {
 	endInterview(client: Socket, server: Server) {
 		this.roomRepository.changeRoomState(client, ROOM_STATE.FEEDBACK);
 		return this.roomRepository.broadcastUserList(client.id, server, ROOM_EVENT.END_INTERVIEW);
+	}
+
+	endFeedback(client: Socket, server: Server) {
+		const feedbackCount = this.roomRepository.countFeedback(client.id, server);
+		if (feedbackCount == END_FLAG) {
+			client.emit(ROOM_EVENT.TERMINATE_SESSION);
+		} else {
+			client.emit(ROOM_EVENT.COUNT_FEEDBACK, feedbackCount);
+		}
 	}
 }

--- a/backend/socket/src/room/room.service.ts
+++ b/backend/socket/src/room/room.service.ts
@@ -36,7 +36,12 @@ export class RoomService {
 	}
 
 	startInterview(client: Socket, server: Server) {
-		this.roomRepository.startInterview(client);
+		this.roomRepository.changeRoomState(client, ROOM_STATE.INTERVIEW);
 		return this.roomRepository.broadcastUserList(client.id, server, ROOM_EVENT.JOIN_INTERVIEW);
+	}
+
+	endInterview(client: Socket, server: Server) {
+		this.roomRepository.changeRoomState(client, ROOM_STATE.FEEDBACK);
+		return this.roomRepository.broadcastUserList(client.id, server, ROOM_EVENT.END_INTERVIEW);
 	}
 }

--- a/backend/socket/src/room/room.service.ts
+++ b/backend/socket/src/room/room.service.ts
@@ -22,16 +22,16 @@ export class RoomService {
 
 	enterRoom(client: Socket, data: string, server: Server) {
 		const { nickname, uuid } = JSON.parse(data);
+
 		client.join(uuid);
+
 		this.roomRepository.enterRoom(client.id, nickname, uuid);
 
-		this.roomRepository.broadcastUserList(data, server);
+		this.roomRepository.broadcastUserList(client.id, server);
 	}
 
-	leaveRoom(client: Socket, data: string, server: Server) {
-		const { uuid } = JSON.parse(data);
-		client.leave(uuid);
-		this.roomRepository.leaveRoom(data, client.id);
-		this.roomRepository.broadcastUserList(data, server);
+	leaveRoom(client: Socket, server: Server) {
+		this.roomRepository.leaveRoom(client);
+		this.roomRepository.broadcastUserList(client.id, server);
 	}
 }

--- a/backend/socket/src/room/room.service.ts
+++ b/backend/socket/src/room/room.service.ts
@@ -1,4 +1,4 @@
-import { ROOM_REPOSITORY_INTERFACE } from '@constant';
+import { ROOM_EVENT, ROOM_REPOSITORY_INTERFACE, ROOM_STATE } from '@constant';
 import { Inject, Injectable } from '@nestjs/common';
 import { Server, Socket } from 'socket.io';
 import { repositoryType } from 'src/types/room.type';
@@ -27,11 +27,16 @@ export class RoomService {
 
 		this.roomRepository.enterRoom(client.id, nickname, uuid);
 
-		this.roomRepository.broadcastUserList(client.id, server);
+		this.roomRepository.broadcastUserList(client.id, server, ROOM_EVENT.USER_ENTER);
 	}
 
 	leaveRoom(client: Socket, server: Server) {
 		this.roomRepository.leaveRoom(client);
-		this.roomRepository.broadcastUserList(client.id, server);
+		this.roomRepository.broadcastUserList(client.id, server, ROOM_EVENT.USER_ENTER);
+	}
+
+	startInterview(client: Socket, server: Server) {
+		this.roomRepository.startInterview(client);
+		return this.roomRepository.broadcastUserList(client.id, server, ROOM_EVENT.JOIN_INTERVIEW);
 	}
 }


### PR DESCRIPTION
작업 중인 PR이라면 제목에 [WIP]을 작성해주세요.

# PR 목적 / 요약
- front page를 만들어서 방 생성, 참가, 나가기까지 테스트 완료
- 인터뷰 시작, 인터뷰 종료, 피드백 시작, 피드백 종료 이벤트 구현 

# 관련 이슈
- close issue #49 

# 리뷰받고 싶은 부분 설명
- repository 부분에 관리해야 하는 자료구조가 좀 많은 거 같은데 동일한 key를 사용하는 경우 하나의 자료구조에서 관리하는 게 좋은지 지금처럼 관리하는 게 좋은 방법인가.

# 특이사항
- 인터뷰가 끝나면 면접자는 대기화면으로 면접관은 피드백화면으로 넘어가야 하는데 유저가 면접자인지 면접관인지 알 수 있는 상태를 가지고 있어야 어느 화면으로 넘어갈지 분기처리를 할 수 있다. 이 상태를 프론트에서 가지고 있을지 백엔드에서 상태를 가지고 있다가 내려줄지 정해야 할 듯하다. 백엔드에서 상태를 가지고 있으면 면접관과 면접자에게 각각 다른 이벤트를 emit하면 되기 때문에 프론트쪽에선 분기처리를 할 필요가 없어질 듯하다.

- 피드백이 끝나면 면접관은 어느 화면에서 기다려야 할지 생각해봐야 할듯하다. 로비로 동시에 이동하기로 정했으니 면접자가 대기하고 있는 화면에서 같이 대기하면 좋을듯하다. 마지막에 피드백을 남긴 사람에 의해서 세션 종료 이벤트가 발생하여 동시에 로비로 이동한다.
