### PR TITLE
mediaStreamer service 추가

### DIFF
--- a/frontend/src/constants/time.constant.ts
+++ b/frontend/src/constants/time.constant.ts
@@ -1,0 +1,3 @@
+export const ONE_SECOND = 1000;
+export const ONE_MINUTE = 1000 * 60;
+export const ONE_HOUR = 1000 * 60 * 60;

--- a/frontend/src/service/mediaRecorder.ts
+++ b/frontend/src/service/mediaRecorder.ts
@@ -1,0 +1,35 @@
+import { socket } from './socket';
+import { ONE_SECOND } from '@constants/time.constant';
+
+const mediaRecorder = () => {
+	let mediaRecorder: MediaRecorder;
+
+	const startRecord = (mediaStream: MediaStream) => {
+		mediaRecorder = new MediaRecorder(mediaStream, {
+			mimeType: 'video/webm; codecs=vp9',
+		});
+
+		mediaRecorder.ondataavailable = (e) => {
+			if (e.data && e.data.size > 0) {
+				socket.emit('stream_video', {
+					timestamp: new Date().getTime(),
+					data: e.data,
+				});
+			}
+		};
+
+		mediaRecorder.onstop = () => {
+			socket.emit('finish_streaming');
+		};
+
+		mediaRecorder.start(ONE_SECOND);
+	};
+
+	const stopRecord = () => {
+		if (mediaRecorder) mediaRecorder.stop();
+	};
+
+	return { startRecord, stopRecord };
+};
+
+export default mediaRecorder;

--- a/frontend/src/service/mediaStreamer.ts
+++ b/frontend/src/service/mediaStreamer.ts
@@ -1,35 +1,35 @@
 import { socket } from './socket';
 import { ONE_SECOND } from '@constants/time.constant';
 
-const mediaRecorder = () => {
+const mediaStreamer = () => {
 	let mediaRecorder: MediaRecorder;
 
-	const startRecord = (mediaStream: MediaStream) => {
+	const startStream = (mediaStream: MediaStream) => {
 		mediaRecorder = new MediaRecorder(mediaStream, {
 			mimeType: 'video/webm; codecs=vp9',
 		});
 
 		mediaRecorder.ondataavailable = (e) => {
-			if (e.data && e.data.size > 0) {
-				socket.emit('stream_video', {
-					timestamp: new Date().getTime(),
-					data: e.data,
-				});
-			}
+			if (!e.data || !e.data.size) return;
+
+			socket.emit('stream_video', {
+				timestamp: new Date().getTime(),
+				data: e.data,
+			});
 		};
 
 		mediaRecorder.onstop = () => {
-			socket.emit('finish_streaming');
+			mediaRecorder = null;
 		};
 
 		mediaRecorder.start(ONE_SECOND);
 	};
 
-	const stopRecord = () => {
+	const stopStream = () => {
 		if (mediaRecorder) mediaRecorder.stop();
 	};
 
-	return { startRecord, stopRecord };
+	return { startStream, stopStream };
 };
 
-export default mediaRecorder;
+export default mediaStreamer;


### PR DESCRIPTION
# PR 목적 / 요약
서버에 면접자의 영상을  전송하기 위한 recorder 서비스 구현

# 관련 이슈
- close issue #70

# 리뷰받고 싶은 부분 설명
- hook으로 관리? service로 관리?
- socket api 명세
- 모듈 이름 
  - mediaStreamer
  - useMediaStreamer

# 특이사항
아래는 대응하는 socket server 코드 예시입니다.
```
const mediaBlobList = [];

socket.on("stream_video", (arg) => {
    const { timestamp, blob } = arg;
    mediaBlobList.push(blob);
});

socket.on("finish_streaming", () => {
    const blob = new Blob(mediaBlobList, { type: "video/webm" });
    uploadVideo(blob);
});

const uploadVideo = (blob) => {
    // upload video to NCP object storage
    return;
};

```