### PR TITLE
[HOTFIX] mediaStreamer 모듈 에러 수정

### DIFF
--- a/frontend/src/pages/Interviewee/Interviewee.tsx
+++ b/frontend/src/pages/Interviewee/Interviewee.tsx
@@ -38,9 +38,21 @@ const Interviewee = () => {
 	};
 
 	useEffect(() => {
+		const effect = () => {
+			console.log('E!');
+			if (!interviewee) return;
+			const myStream = getStreamFromUUID(interviewee.uuid);
+			if (!myStream) return;
+			startStream(myStream);
+		};
+		effect();
+		return stopStream;
+	}, []);
+
+	useEffect(() => {
 		socket.on(SOCKET_EVENT_TYPE.START_WAITING, ({ docsUUID }) => {
 			setDocsUUID(docsUUID);
-			stopStream(docsUUID);
+			socketEmit('finish_streaming', docsUUID);
 			const docsRequestDto: DocsReqDtoType = {
 				roomUUID: interviewee.roomUUID,
 				docsUUID,
@@ -49,20 +61,11 @@ const Interviewee = () => {
 			axios.post(REST_TYPE.INTERVIEW_DOCS, docsRequestDto);
 			safeNavigate(PAGE_TYPE.WAITTING_PAGE);
 		});
+
 		return () => {
 			socket.off(SOCKET_EVENT_TYPE.START_WAITING);
 		};
 	}, [currentVideoTime]);
-
-	useEffect(() => {
-		const effect = () => {
-			if (!interviewee) return;
-			const myStream = getStreamFromUUID(interviewee.uuid);
-			if (!myStream) return;
-			startStream(myStream);
-		};
-		effect();
-	}, [webRTCUserMap, interviewee]);
 
 	return (
 		<>

--- a/frontend/src/service/mediaStreamer.ts
+++ b/frontend/src/service/mediaStreamer.ts
@@ -1,6 +1,5 @@
 import { socket } from './socket';
 import { ONE_SECOND } from '@constants/time.constant';
-import { socketEmit } from '@api/socket.api';
 
 const mediaStreamer = () => {
 	let mediaRecorder: MediaRecorder;
@@ -9,7 +8,6 @@ const mediaStreamer = () => {
 		mediaRecorder = new MediaRecorder(mediaStream, {
 			mimeType: 'video/webm; codecs=vp9',
 		});
-		console.log('start stream');
 
 		mediaRecorder.ondataavailable = async (e) => {
 			if (!e.data || !e.data.size) return;
@@ -23,11 +21,8 @@ const mediaStreamer = () => {
 		mediaRecorder.start(ONE_SECOND);
 	};
 
-	const stopStream = (docsUUID: string) => {
-		if (mediaRecorder) {
-			mediaRecorder.stop();
-			socketEmit('finish_streaming', docsUUID);
-		}
+	const stopStream = () => {
+		if (mediaRecorder) mediaRecorder.stop();
 	};
 
 	return { startStream, stopStream };


### PR DESCRIPTION
# PR 목적 / 요약
- service 모듈이 리액트 랜더링 라이프사이클과 연관되며 클린업 하는 시점에 mediaRecord가 소실됨

# 연관 이슈
- close issue #155 