### PR TITLE
User Selector에서 User 정보와 connection, stream 정보를 병합하여 관리하도록 변경

### DIFF
--- a/frontend/src/components/@drawer/UserDrawer/UserDrawer.tsx
+++ b/frontend/src/components/@drawer/UserDrawer/UserDrawer.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useRecoilValue } from 'recoil';
 
-import { meInRoomState, othersInRoomState } from '@store/room.store';
 import { ReactComponent as CopyIcon } from '@assets/icon/copy.svg';
 import { ReactComponent as MicOnIcon } from '@assets/icon/mic_on.svg';
 import { ReactComponent as MicOffIcon } from '@assets/icon/mic_off.svg';
@@ -14,6 +13,7 @@ import {
 	userListStyle,
 } from './UserDrawer.style';
 import { iconSmStyle } from '@styles/commonStyle';
+import { meInRoomState, othersInRoomState } from '@store/user.store';
 
 const UserDrawer = () => {
 	const others = useRecoilValue(othersInRoomState);

--- a/frontend/src/components/@modal/EnterRoomModal.tsx
+++ b/frontend/src/components/@modal/EnterRoomModal.tsx
@@ -7,7 +7,8 @@ import { UserType } from '@customType/user';
 import useSafeNavigate from '@hooks/useSafeNavigate';
 import { PAGE_TYPE } from '@constants/page.constant';
 import { useSetRecoilState } from 'recoil';
-import { meInRoomState, othersInRoomState, roomUUIDState } from '@store/room.store';
+import { roomUUIDState } from '@store/room.store';
+import { meInRoomState, othersInRoomState } from '@store/user.store';
 
 interface attendRoomResponseType {
 	success?: boolean;

--- a/frontend/src/components/@modal/StartInterviewModal.tsx
+++ b/frontend/src/components/@modal/StartInterviewModal.tsx
@@ -6,32 +6,24 @@ import { SOCKET_EVENT_TYPE } from '@constants/socket.constant';
 import useModal from '@hooks/useModal';
 import useSafeNavigate from '@hooks/useSafeNavigate';
 import { UserType } from '@customType/user';
-import { SetterOrUpdater } from 'recoil';
-
-export interface StartInterviewModalPropType {
-	me: UserType;
-	setMe: SetterOrUpdater<UserType>;
-	others: UserType[];
-	setOthers: SetterOrUpdater<UserType[]>;
-}
+import { useUserRole } from '@hooks/useUserRole';
+import { useRecoilValue } from 'recoil';
+import { meInRoomState } from '@store/room.store';
 
 interface joinInterviewResponseType {
 	usersInRoom: UserType[];
 }
 
-const StartInterviewModal = ({ me, setMe, others, setOthers }: StartInterviewModalPropType) => {
+const StartInterviewModal = () => {
 	const { closeModal } = useModal();
 	const { safeNavigate } = useSafeNavigate();
+	const { setUserRole } = useUserRole();
+	const me = useRecoilValue(meInRoomState);
 
 	const handleStartInterviewee = async () => {
 		await socketEmit<joinInterviewResponseType>(SOCKET_EVENT_TYPE.START_INTERVIEW);
 
-		const newOthers = others.map((user) => {
-			return { ...user, role: 'interviewer' };
-		});
-
-		setMe({ ...me, role: 'interviewee' });
-		setOthers(newOthers);
+		setUserRole(me);
 		closeModal();
 		safeNavigate(PAGE_TYPE.INTERVIEWEE_PAGE);
 	};

--- a/frontend/src/constants/role.constant.ts
+++ b/frontend/src/constants/role.constant.ts
@@ -1,0 +1,5 @@
+export enum ROLE_TYPE {
+	NONE = 'none',
+	INTERVIEWEE = 'interviewee',
+	INTERVIEWER = 'interviewer',
+}

--- a/frontend/src/hooks/useCleanupRoom.ts
+++ b/frontend/src/hooks/useCleanupRoom.ts
@@ -1,5 +1,5 @@
-import { meInRoomState, othersInRoomState, roomUUIDState } from '@store/room.store';
-import { webRTCUserMapState } from '@store/webRTC.store';
+import { roomUUIDState } from '@store/room.store';
+import { meInRoomState, othersInRoomState, webRTCUserMapState } from '@store/user.store';
 import { useCallback } from 'react';
 import { useResetRecoilState } from 'recoil';
 import useCleanupInterview from './useCleanupInterview';

--- a/frontend/src/hooks/useUserRole.ts
+++ b/frontend/src/hooks/useUserRole.ts
@@ -1,6 +1,6 @@
 import { ROLE_TYPE } from '@constants/role.constant';
 import { UserType } from '@customType/user';
-import { meInRoomState, othersInRoomState } from '@store/room.store';
+import { meInRoomState, othersInRoomState } from '@store/user.store';
 import { useRecoilState } from 'recoil';
 
 export const useUserRole = () => {

--- a/frontend/src/hooks/useUserRole.ts
+++ b/frontend/src/hooks/useUserRole.ts
@@ -1,0 +1,34 @@
+import { ROLE_TYPE } from '@constants/role.constant';
+import { UserType } from '@customType/user';
+import { meInRoomState, othersInRoomState } from '@store/room.store';
+import { useRecoilState } from 'recoil';
+
+export const useUserRole = () => {
+	const [me, setMe] = useRecoilState<UserType>(meInRoomState);
+	const [others, setOthers] = useRecoilState<UserType[]>(othersInRoomState);
+
+	const setUserRole = (interviewee) => {
+		const newOthers = others.map((user) => {
+			return user.uuid === interviewee.uuid
+				? { ...user, role: ROLE_TYPE.INTERVIEWEE }
+				: { ...user, role: ROLE_TYPE.INTERVIEWER };
+		});
+
+		setOthers(newOthers);
+		setMe({
+			...me,
+			role: interviewee.uuid === me.uuid ? ROLE_TYPE.INTERVIEWEE : ROLE_TYPE.INTERVIEWER,
+		});
+	};
+
+	const resetUserRole = () => {
+		const newOthers = others.map((user) => {
+			return { ...user, role: ROLE_TYPE.NONE };
+		});
+
+		setOthers(newOthers);
+		setMe({ ...me, role: ROLE_TYPE.NONE });
+	};
+
+	return { setUserRole, resetUserRole };
+};

--- a/frontend/src/pages/Interviewee/Interviewee.tsx
+++ b/frontend/src/pages/Interviewee/Interviewee.tsx
@@ -5,9 +5,9 @@ import axios from 'axios';
 import IntervieweeVideo from '@components/IntervieweeVideo/IntervieweeVideo';
 import useSafeNavigate from '@hooks/useSafeNavigate';
 import usePreventLeave from '@hooks/usePreventLeave';
-import { webRTCStreamSelector } from '@store/webRTC.store';
+import { userRoleSelector } from '@store/webRTC.store';
 import { currentVideoTimeState } from '@store/currentVideoTime.store';
-import { docsUUIDState, userRoleSelector } from '@store/interview.store';
+import { docsUUIDState } from '@store/interview.store';
 
 import { socket } from '@service/socket';
 import mediaStreamer from '@service/mediaStreamer';
@@ -30,7 +30,6 @@ const Interviewee = () => {
 
 	const { interviewee, interviewerList } = useRecoilValue(userRoleSelector);
 	const currentVideoTime = useRecoilValue(currentVideoTimeState);
-	const streamList = useRecoilValue(webRTCStreamSelector);
 	const setDocsUUID = useSetRecoilState(docsUUIDState);
 
 	const hadleEndInterview = () => {
@@ -41,15 +40,10 @@ const Interviewee = () => {
 		openModal('CancelInterviewModal');
 	};
 
-	const getStreamFromUUID = (uuid) => {
-		return streamList.find((stream) => stream.uuid === uuid).stream;
-	};
-
 	useEffect(() => {
 		const effect = () => {
-			console.log('E!');
 			if (!interviewee) return;
-			const myStream = getStreamFromUUID(interviewee.uuid);
+			const myStream = interviewee.stream;
 			if (!myStream) return;
 			startStream(myStream);
 		};
@@ -102,7 +96,7 @@ const Interviewee = () => {
 		<div css={intervieweeWrapperStyle}>
 			<IntervieweeVideo
 				key={interviewee.uuid}
-				src={getStreamFromUUID(interviewee.uuid)}
+				src={interviewee.stream}
 				nickname={interviewee.uuid}
 				width={'400px'}
 				autoplay
@@ -111,7 +105,7 @@ const Interviewee = () => {
 			{interviewerList.map((interviewer) => (
 				<StreamVideo
 					key={interviewer.uuid}
-					src={getStreamFromUUID(interviewer.uuid)}
+					src={interviewer.stream}
 					nickname={interviewer.uuid}
 					width={'400px'}
 					muted

--- a/frontend/src/pages/Interviewee/Interviewee.tsx
+++ b/frontend/src/pages/Interviewee/Interviewee.tsx
@@ -5,7 +5,7 @@ import axios from 'axios';
 import IntervieweeVideo from '@components/IntervieweeVideo/IntervieweeVideo';
 import useSafeNavigate from '@hooks/useSafeNavigate';
 import usePreventLeave from '@hooks/usePreventLeave';
-import { userRoleSelector } from '@store/webRTC.store';
+import { userRoleSelector } from '@store/user.store';
 import { currentVideoTimeState } from '@store/currentVideoTime.store';
 import { docsUUIDState } from '@store/interview.store';
 

--- a/frontend/src/pages/Interviewer/Interviewer.tsx
+++ b/frontend/src/pages/Interviewer/Interviewer.tsx
@@ -1,24 +1,25 @@
 import React, { useEffect } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import IntervieweeVideo from '@components/IntervieweeVideo/IntervieweeVideo';
 import FeedbackList from '@components/FeedbackList/FeedbackList';
 import useSafeNavigate from '@hooks/useSafeNavigate';
 import usePreventLeave from '@hooks/usePreventLeave';
-import { webRTCStreamSelector } from '@store/webRTC.store';
-import { docsUUIDState, userRoleSelector } from '@store/interview.store';
+import { docsUUIDState } from '@store/interview.store';
 import { feedbackListSelector } from '@store/feedback.store';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
-import { socket } from '../../service/socket';
+import { socket } from '@service/socket';
 import { PAGE_TYPE } from '@constants/page.constant';
 import { SOCKET_EVENT_TYPE } from '@constants/socket.constant';
-import { interviewerContainerStyle, interviewerWrapperStyle } from './Interviewer.style';
 import RoundButton from '@components/@shared/RoundButton/RoundButton';
 import BottomBar from '@components/BottomBar/BottomBar';
 import FeedbackForm from '@components/FeedbackForm/FeedbackForm';
 import { feedbackAreaStyle } from '@pages/Feedback/Feedback.style';
 import StreamVideo from '@components/@shared/StreamingVideo/StreamVideo';
 import useModal from '@hooks/useModal';
+import { userRoleSelector } from '@store/webRTC.store';
+
+import { interviewerContainerStyle, interviewerWrapperStyle } from './Interviewer.style';
 
 const Interviewer = () => {
 	const { openModal } = useModal();
@@ -27,7 +28,6 @@ const Interviewer = () => {
 
 	const feedbackList = useRecoilValue(feedbackListSelector);
 	const { interviewee, interviewerList } = useRecoilValue(userRoleSelector);
-	const streamList = useRecoilValue(webRTCStreamSelector);
 	const setDocsUUID = useSetRecoilState(docsUUIDState);
 
 	const hadleEndInterview = () => {
@@ -36,10 +36,6 @@ const Interviewer = () => {
 
 	const hadleCancelInterview = () => {
 		openModal('CancelInterviewModal');
-	};
-
-	const getStreamFromUUID = (uuid) => {
-		return streamList.find((stream) => stream.uuid === uuid).stream;
 	};
 
 	useEffect(() => {
@@ -78,7 +74,7 @@ const Interviewer = () => {
 				<div>
 					<IntervieweeVideo
 						key={interviewee.uuid}
-						src={getStreamFromUUID(interviewee.uuid)}
+						src={interviewee.stream}
 						nickname={interviewee.uuid}
 						width={'400px'}
 						autoplay
@@ -87,7 +83,7 @@ const Interviewer = () => {
 					{interviewerList.map((interviewer) => (
 						<StreamVideo
 							key={interviewer.uuid}
-							src={getStreamFromUUID(interviewer.uuid)}
+							src={interviewer.stream}
 							nickname={interviewer.uuid}
 							width={'200px'}
 							muted

--- a/frontend/src/pages/Interviewer/Interviewer.tsx
+++ b/frontend/src/pages/Interviewer/Interviewer.tsx
@@ -17,7 +17,7 @@ import FeedbackForm from '@components/FeedbackForm/FeedbackForm';
 import { feedbackAreaStyle } from '@pages/Feedback/Feedback.style';
 import StreamVideo from '@components/@shared/StreamingVideo/StreamVideo';
 import useModal from '@hooks/useModal';
-import { userRoleSelector } from '@store/webRTC.store';
+import { userRoleSelector } from '@store/user.store';
 
 import { interviewerContainerStyle, interviewerWrapperStyle } from './Interviewer.style';
 

--- a/frontend/src/pages/Landing/Landing.style.ts
+++ b/frontend/src/pages/Landing/Landing.style.ts
@@ -20,6 +20,7 @@ export const headerStyle = () => css`
 	${flexRow({ justifyContent: 'space-between' })};
 
 	width: 100%;
+	height: 72px;
 
 	padding: 16px 24px;
 `;

--- a/frontend/src/pages/Landing/Landing.tsx
+++ b/frontend/src/pages/Landing/Landing.tsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 
 import isAuthQuery from '@store/auth.store';
-import { meInRoomState, othersInRoomState, roomUUIDState } from '@store/room.store';
+import { roomUUIDState } from '@store/room.store';
 import useSafeNavigate from '@hooks/useSafeNavigate';
 import usePreventLeave from '@hooks/usePreventLeave';
 
@@ -29,6 +29,7 @@ import {
 } from './Landing.style';
 import Button from '@components/@shared/Button/Button';
 import useModal from '@hooks/useModal';
+import { meInRoomState, othersInRoomState } from '@store/user.store';
 
 interface createRoomResponseType {
 	uuid: string;

--- a/frontend/src/pages/Lobby/Lobby.tsx
+++ b/frontend/src/pages/Lobby/Lobby.tsx
@@ -6,8 +6,12 @@ import BottomBar from '@components/BottomBar/BottomBar';
 import useSafeNavigate from '@hooks/useSafeNavigate';
 import usePreventLeave from '@hooks/usePreventLeave';
 import useWebRTCSignaling from '@hooks/useWebRTCSignaling';
-import { meInRoomState, othersInRoomState } from '@store/room.store';
-import { userInfoSelector, webRTCUserMapState } from '@store/webRTC.store';
+import {
+	meInRoomState,
+	othersInRoomState,
+	userInfoSelector,
+	webRTCUserMapState,
+} from '@store/user.store';
 
 import { socket } from '../../service/socket';
 import { UserType } from '@customType/user';

--- a/frontend/src/pages/Waiting/Waiting.tsx
+++ b/frontend/src/pages/Waiting/Waiting.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
-import { othersInRoomState } from '@store/room.store';
 import { completedFbCntState } from '@store/interview.store';
 import usePreventLeave from '@hooks/usePreventLeave';
 import useSafeNavigate from '@hooks/useSafeNavigate';
@@ -11,6 +10,7 @@ import { socket } from '../../service/socket';
 import BottomBar from '@components/BottomBar/BottomBar';
 import { waitingWrapperStyle } from './Waiting.style';
 import useCleanupInterview from '@hooks/useCleanupInterview';
+import { othersInRoomState } from '@store/user.store';
 
 const Waiting = () => {
 	usePreventLeave();

--- a/frontend/src/store/interview.store.ts
+++ b/frontend/src/store/interview.store.ts
@@ -1,5 +1,4 @@
-import { atom, selector } from 'recoil';
-import { meInRoomState, othersInRoomState } from './room.store';
+import { atom } from 'recoil';
 
 export const docsUUIDState = atom({
 	key: 'docsUUIDState',
@@ -9,21 +8,4 @@ export const docsUUIDState = atom({
 export const completedFbCntState = atom({
 	key: 'completedFbCntState',
 	default: 0,
-});
-
-export const userRoleSelector = selector({
-	key: 'userRoleSelector',
-	get: ({ get }) => {
-		const totalUser = [get(meInRoomState), ...get(othersInRoomState)];
-
-		return totalUser.reduce(
-			(acc, cur) => {
-				if (cur.role === 'interviewee') acc.interviewee = cur;
-				else acc.interviewerList.push(cur);
-
-				return acc;
-			},
-			{ interviewee: null, interviewerList: [] }
-		);
-	},
 });

--- a/frontend/src/store/room.store.ts
+++ b/frontend/src/store/room.store.ts
@@ -1,17 +1,6 @@
-import { UserType } from '@customType/user';
 import { atom } from 'recoil';
 
 export const roomUUIDState = atom({
 	key: 'roomUUIDState',
-	default: null,
-});
-
-export const othersInRoomState = atom<UserType[]>({
-	key: 'othersInRoomState',
-	default: [],
-});
-
-export const meInRoomState = atom<UserType>({
-	key: 'meInRoomState',
 	default: null,
 });

--- a/frontend/src/store/user.store.ts
+++ b/frontend/src/store/user.store.ts
@@ -1,13 +1,23 @@
+import { UserType } from '@customType/user';
 import { atom, selector } from 'recoil';
-import { meInRoomState, othersInRoomState } from './room.store';
 
 export const webRTCUserMapState = atom({
 	key: 'webRTCUserMapState',
 	default: new Map(),
 });
 
+export const othersInRoomState = atom<UserType[]>({
+	key: 'othersInRoomState',
+	default: [],
+});
+
+export const meInRoomState = atom<UserType>({
+	key: 'meInRoomState',
+	default: null,
+});
+
 export const userInfoSelector = selector({
-	key: 'webRTCStreamSelector',
+	key: 'userInfoSelector',
 	get: ({ get }) => {
 		return Array.from(get(webRTCUserMapState).entries()).map((userInfo) => {
 			const [uuid, { connection, stream }] = userInfo;

--- a/frontend/src/store/webRTC.store.ts
+++ b/frontend/src/store/webRTC.store.ts
@@ -1,16 +1,37 @@
 import { atom, selector } from 'recoil';
+import { meInRoomState, othersInRoomState } from './room.store';
 
 export const webRTCUserMapState = atom({
 	key: 'webRTCUserMapState',
 	default: new Map(),
 });
 
-export const webRTCStreamSelector = selector({
+export const userInfoSelector = selector({
 	key: 'webRTCStreamSelector',
 	get: ({ get }) => {
 		return Array.from(get(webRTCUserMapState).entries()).map((userInfo) => {
-			const [uuid, { stream }] = userInfo;
-			return { uuid, stream };
+			const [uuid, { connection, stream }] = userInfo;
+			const targetUser = get(othersInRoomState).find((user) => user.uuid === uuid);
+			if (!targetUser) return { ...get(meInRoomState), connection, stream };
+
+			return { ...targetUser, connection, stream };
 		});
+	},
+});
+
+export const userRoleSelector = selector({
+	key: 'userRoleSelector',
+	get: ({ get }) => {
+		const totalUser = get(userInfoSelector);
+
+		return totalUser.reduce(
+			(acc, cur) => {
+				if (cur.role === 'interviewee') acc.interviewee = cur;
+				else acc.interviewerList.push(cur);
+
+				return acc;
+			},
+			{ interviewee: null, interviewerList: [] }
+		);
 	},
 });


### PR DESCRIPTION
작업 중인 PR이라면 제목에 [WIP]을 작성해주세요.

# PR 목적 / 요약

원래 목적은 me와 others에 webRTC connection, stream 정보를 병합하는 것이었으나
others가 webRTC 훅 외부에서도 업데이트가 이루어지기 때문에
webRTC 훅과 others 상태 업데이트 과정을 직렬화하기 어려웠습니다.

이 구조를 손보기 위해서는 많은 시간을 들여야할 것으로 예상하여, 
임시 조치로 streamList를 가져오는데 사용하였던 webRTCStreamSelector와 userRoleSelector에서
user 정보와 connection, stream 정보를 통합하여 return 하도록 변경하였습니다.

이에 따라 webRTCStreamSelector는 userInfoSelector로 이름이 변경되었습니다.

# 관련 이슈

- close issue #150 

# 리뷰받고 싶은 부분 설명

user.store.ts가 변경된 메인 부분입니다.

# 특이사항

없음.